### PR TITLE
Update client refresh logic. Resolution changes no longer require a c…

### DIFF
--- a/components/Helpers/helpers.js
+++ b/components/Helpers/helpers.js
@@ -1,3 +1,15 @@
+function formatConfig(config) {
+  const streamConfig = {
+    maxResolution: {
+      width: config.w,
+      height: config.h,
+    },
+    maxFramerate: 30,
+    maxBitrate: config.bitrate,
+  };
+  return streamConfig;
+}
+
 function getConfigFromResolution(resolution, channelType) {
   var config, bitrate;
   switch (resolution) {
@@ -42,7 +54,8 @@ function getConfigFromResolution(resolution, channelType) {
       };
       break;
   }
-  return config;
+  const streamConfig = formatConfig(config);
+  return streamConfig;
 }
 
 export { getConfigFromResolution };

--- a/components/ScreenShare/useScreenShare.js
+++ b/components/ScreenShare/useScreenShare.js
@@ -5,7 +5,7 @@ const SCREENSHARE_MIXER_NAME = 'screen-audio';
 const CAM_LAYER_NAME = 'camera';
 const CAM_PADDING = 20;
 
-const useScreenShare = (dimensions) => {
+const useScreenShare = () => {
   const [captureStream, setCaptureStream] = useState(null);
 
   const getCaptureStream = async () => {
@@ -50,7 +50,8 @@ const useScreenShare = (dimensions) => {
     camMuted,
     updateLayer,
     addLayer,
-    client
+    client,
+    canvas
   ) => {
     const layer = {
       stream: screenCaptureStream,
@@ -65,10 +66,10 @@ const useScreenShare = (dimensions) => {
       name: CAM_LAYER_NAME,
       index: 4,
       visible: camMuted,
-      x: dimensions.width - dimensions.width / 4 - CAM_PADDING,
-      y: dimensions.height - dimensions.height / 4 - CAM_PADDING,
-      width: dimensions.width / 4,
-      height: dimensions.height / 4,
+      x: canvas.width - canvas.width / 4 - CAM_PADDING,
+      y: canvas.height - canvas.height / 4 - CAM_PADDING,
+      width: canvas.width / 4,
+      height: canvas.height / 4,
       type: 'VIDEO',
     };
 
@@ -85,6 +86,7 @@ const useScreenShare = (dimensions) => {
     removeLayer,
     removeMixerDevice,
     addAudioTrack,
+    canvas,
     client
   ) => {
     try {
@@ -108,7 +110,8 @@ const useScreenShare = (dimensions) => {
         camMuted,
         updateLayer,
         addLayer,
-        client
+        client,
+        canvas
       );
 
       startAudioShare(screenCaptureStream, addAudioTrack, client);

--- a/components/Stream/useStream.js
+++ b/components/Stream/useStream.js
@@ -9,21 +9,9 @@ const useStream = () => {
     ingestServer,
     streamKey,
     channelType,
-    streamResolution,
     client,
     handleError
   ) => {
-    // Get the actual width and height from the selected resolution
-    const parsedConfig = getConfigFromResolution(streamResolution, channelType);
-    client.config.streamConfig = {
-      maxResolution: {
-        width: parsedConfig.w,
-        height: parsedConfig.h,
-      },
-      maxFramerate: 30,
-      maxBitrate: parsedConfig.bitrate,
-    };
-
     var timer;
     try {
       // Set the ingest server to re-validate it before attempting to start the stream.
@@ -52,7 +40,7 @@ const useStream = () => {
       switch (err.code) {
         case 10000:
           handleError(
-            `Error starting stream: Your stream settings are misconfigured. The Channel type you selected: ${
+            `Error starting stream: Your stream settings are misconfigured. This is likely caused by mismatched channel types. The Channel type you selected: ${
               channelType === 'STANDARD' ? 'Standard' : 'Basic'
             }, must match the channel type of your Amazon IVS Channel.`
           );
@@ -84,21 +72,13 @@ const useStream = () => {
     ingestServer,
     streamKey,
     channelType,
-    streamResolution,
     client,
     handleError
   ) => {
     if (isLive) {
       stopStream(client, handleError);
     } else {
-      startStream(
-        ingestServer,
-        streamKey,
-        channelType,
-        streamResolution,
-        client,
-        handleError
-      );
+      startStream(ingestServer, streamKey, channelType, client, handleError);
     }
   };
 

--- a/components/StreamPreview/useLayers.js
+++ b/components/StreamPreview/useLayers.js
@@ -76,14 +76,14 @@ const useLayers = (initialLayer) => {
 
         // If a layer with the same name is already added, remove it
         if (client.getVideoInputDevice(layer.name)) {
-          removeLayer(layer, client);
+          await removeLayer(layer, client);
         }
 
         // Width: 1920, Height: 1080 is 16:9 "1080p"
         // Width: 3840, Height: 2160 is 16:9 "4k"
         const cameraStream = await navigator.mediaDevices.getUserMedia({
           video: {
-            deviceId: device.deviceId,
+            deviceId: { exact: device.deviceId },
             width: {
               ideal: 1920,
               max: 3840,
@@ -114,7 +114,7 @@ const useLayers = (initialLayer) => {
 
         // If a layer with the same name is already added, remove it
         if (client.getVideoInputDevice(layer.name)) {
-          removeLayer(layer, client);
+          await removeLayer(layer, client);
         }
 
         await client.addVideoInputDevice(stream, name, layerProps);
@@ -132,7 +132,7 @@ const useLayers = (initialLayer) => {
 
       // If a layer with the same name is already added, throw an error
       if (client.getVideoInputDevice(layer.name)) {
-        removeLayer(layer, client);
+        await removeLayer(layer, client);
       }
 
       const img = new Image();
@@ -160,9 +160,21 @@ const useLayers = (initialLayer) => {
       if (!name) return;
       switch (layer.type) {
         case 'VIDEO':
+          const videoStream = client.getVideoInputDevice(name);
+          if (videoStream) {
+            for (const track of videoStream.source.getVideoTracks()) {
+              track.stop();
+            }
+          }
           await client.removeVideoInputDevice(name);
           break;
         case 'SCREENSHARE':
+          const screenShareStream = client.getVideoInputDevice(name);
+          if (screenShareStream) {
+            for (const track of screenShareStream.source.getVideoTracks()) {
+              track.stop();
+            }
+          }
           await client.removeVideoInputDevice(name);
           break;
         case 'IMAGE':

--- a/yarn.lock
+++ b/yarn.lock
@@ -1021,9 +1021,9 @@ json-stable-stringify-without-jsonify@^1.0.1:
   integrity sha1-nbe1lJatPzz+8wp1FC0tkwrXJlE=
 
 json5@^1.0.1:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/json5/-/json5-1.0.2.tgz#63d98d60f21b313b77c4d6da18bfa69d80e1d593"
-  integrity sha512-g1MWMLBiz8FKi1e4w0UyVL3w+iJceWAFBAaBnnGKOpNa5f8TLktkbre1+s6oICydWAm+HRUGTmI+//xv2hvXYA==
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/json5/-/json5-1.0.1.tgz#779fb0018604fa854eacbf6252180d83543e3dbe"
+  integrity sha512-aKS4WQjPenRxiQsC93MNfjx+nbF4PAdYzmd/1JIj8HYzqfbu86beTuNgXDzPknWk0n0uARlyewZo4s++ES36Ow==
   dependencies:
     minimist "^1.2.0"
 
@@ -1103,9 +1103,9 @@ minimatch@^3.0.4:
     brace-expansion "^1.1.7"
 
 minimist@^1.2.0:
-  version "1.2.7"
-  resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.7.tgz#daa1c4d91f507390437c6a8bc01078e7000c4d18"
-  integrity sha512-bzfL1YUZsP41gmu/qjrEk0Q6i2ix/cVeAhbCbqH9u3zYutS1cLg00qhrD0M2MVdCcx4Sc0UpP2eBWo9rotpq6g==
+  version "1.2.5"
+  resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.5.tgz#67d66014b66a6a8aaa0c083c5fd58df4e4e97602"
+  integrity sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==
 
 moment@^2.29.4:
   version "2.29.4"


### PR DESCRIPTION
*Description of changes:*
- Refactor `streamConfig` changes so that they no longer require the brittle client `delete()` operation when changing resolution and bitrate settings.
- Use `useRef()` instead of `useState()` to store references to the currently selected stream resolution and channel type to prevent async issues when re-initializing layers on resolution changes.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
