### PR TITLE
Bugfix: Fix stretched video on iOS.

### DIFF
--- a/components/Settings/Settings.js
+++ b/components/Settings/Settings.js
@@ -243,7 +243,13 @@ export default function Settings({
           {isSupported ? (
             <div className={styles.previewWrapper}>
               <div className={styles.previewInner}>
-                <video className={styles.previewVideo} ref={previewRef}></video>
+                <video
+                  autoPlay={true}
+                  playsInline={true}
+                  muted={true}
+                  className={styles.previewVideo}
+                  ref={previewRef}
+                ></video>
               </div>
             </div>
           ) : (

--- a/components/StreamPreview/useLayers.js
+++ b/components/StreamPreview/useLayers.js
@@ -1,4 +1,5 @@
 import { useState } from 'react';
+import { isIOS, isAndroid } from 'react-device-detect';
 
 // Keeps track of layer state on the canvas.
 
@@ -81,20 +82,32 @@ const useLayers = (initialLayer) => {
 
         // Width: 1920, Height: 1080 is 16:9 "1080p"
         // Width: 3840, Height: 2160 is 16:9 "4k"
+        let width = { ideal: 1280, max: 3840 };
+        let height = { ideal: 720, max: 2160 };
+        let aspect = { ideal: 16 / 9 };
+
+        // If the user is on a mobile device, flip the width and height when in portrait
+        // This fixes a common issue on iOS and Android
+        if (isIOS || isAndroid) {
+          width = { ideal: 720, max: 2160 };
+          height = { ideal: 1280, max: 3840 };
+          aspect = { ideal: 9 / 16 };
+        }
+
         const cameraStream = await navigator.mediaDevices.getUserMedia({
           video: {
             deviceId: { exact: device.deviceId },
             width: {
-              ideal: 1920,
-              max: 3840,
+              ideal: width.ideal,
+              max: width.max,
             },
             height: {
-              ideal: 1080,
-              max: 2160,
+              ideal: height.ideal,
+              max: height.max,
             },
           },
           audio: true,
-          aspectRatio: { ideal: 16 / 9 },
+          aspectRatio: aspect.ideal,
           frameRate: 30,
         });
 

--- a/pages/index.js
+++ b/pages/index.js
@@ -100,7 +100,7 @@ export default function Broadcast() {
 
   const handlePermissions = async () => {
     try {
-      // Width and height are set to attempt to get max resolution video feed
+      // See useLayers.js > addVideoLayer() to modify the requested webcam resolution
       const stream = await navigator.mediaDevices.getUserMedia({
         video: true,
         audio: true,


### PR DESCRIPTION
*Description of changes:*
Update getUserMedia to flip width and height on mobile devices to get landscape video on mobile devices in portrait orientation.

This fix does not include portrait video for mobile - support for portrait/landscape aspect selection will be added in a future update.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
