### PR TITLE
chore: bump broadcast sdk to 1.15

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   "dependencies": {
     "@headlessui/react": "^2.0.4",
     "@heroicons/react": "^2.1.3",
-    "amazon-ivs-web-broadcast": "^1.14.0",
+    "amazon-ivs-web-broadcast": "^1.15.0",
     "clsx": "^2.1.1",
     "core-js-pure": "3.37.1",
     "expr-eval": "^2.0.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -407,10 +407,10 @@ ajv@^6.12.4:
     json-schema-traverse "^0.4.1"
     uri-js "^4.2.2"
 
-amazon-ivs-web-broadcast@^1.14.0:
-  version "1.14.0"
-  resolved "https://registry.yarnpkg.com/amazon-ivs-web-broadcast/-/amazon-ivs-web-broadcast-1.14.0.tgz#973f8bc4e6d3232ece22fb4395745209429486b5"
-  integrity sha512-qoTGGyjGv2Il1JuTuL3PfMpi0hqR49kbm3zRMCR6DkoOkvPNIZFNr7O28szE9UkXyZEnBiQqAaAJOE76mcrqkQ==
+amazon-ivs-web-broadcast@^1.15.0:
+  version "1.15.0"
+  resolved "https://registry.yarnpkg.com/amazon-ivs-web-broadcast/-/amazon-ivs-web-broadcast-1.15.0.tgz#e2d7d57466cc7eb94c80e035b6980d597c8d35ee"
+  integrity sha512-iJza5y81GwjEf1b8wt2YZeQq2B3xw79f8vp3MUofiEhE3bXIdPpPpuKPAN5DJHf4152HYtrvV7tOjKjeDv07Fg==
   dependencies:
     axios "0.27.2"
     bowser "^2.11.0"


### PR DESCRIPTION
*Description of changes:*
Update IVS Broadcast SDK to 1.15.0

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
